### PR TITLE
Fix: Complete the automation steps to enable bot add contributors 

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,0 +1,18 @@
+{
+  "projectName": "node-mongo",
+  "projectOwner": "code-collabo",
+  "repoType": "github",
+  "repoHost": "https://github.com",
+  "files": [
+    "README.md"
+  ],
+  "imageSize": 100,
+  "commit": false,
+  "contributorsPerLine": 6,
+  "contributorsSortAlphabetically": true,
+  "skipCi": true,
+  "contributors": [
+  ],
+  "commitConvention": "angular",
+  "commitType": "docs"
+}


### PR DESCRIPTION
 - [x] The .all-contributorsrc file is created in the Git and Github for collaboration repo
 - [x] The content is same as the example .all-contributorsrc file given (but content modified to suit the Git and Github for collaboration repo accordingly)
 - [x] I certify that I ran my checklist