### PR TITLE
Fix: Complete the automation steps to enable bot add contributors

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,0 +1,18 @@
+{
+  "projectName": "node-mongo",
+  "projectOwner": "code-collabo",
+  "repoType": "github",
+  "repoHost": "https://github.com",
+  "files": [
+    "README.md"
+  ],
+  "imageSize": 100,
+  "commit": false,
+  "contributorsPerLine": 6,
+  "contributorsSortAlphabetically": true,
+  "skipCi": true,
+  "contributors": [
+  ],
+  "commitConvention": "angular",
+  "commitType": "docs"
+}


### PR DESCRIPTION
#### This pull request makes the following changes:
- Fixes code-collabo/docs#33

Checklist
-  [x] The .all-contributorsrc file is created in Git and GitHub for the collaboration repo
-  [x] The content is the same as in the example .all-contributorsrc file given (but content modified to suit Git and GitHub for collaboration repo accordingly)
- [x] I certify that I ran my checklist

ping  @code-collabo/community-mentors